### PR TITLE
Update/support more brands

### DIFF
--- a/components/staging/index.js
+++ b/components/staging/index.js
@@ -364,7 +364,7 @@ const Staging = ({methods, constants, Components, ...props}) => {
     };
 
 	return (
-		<Components.Page title={__('Staging', 'wp-plugin-bluehost')} className={methods.classnames('newfold-staging-page',  getClasses())}>
+		<Components.Page title={constants.text.title} className={methods.classnames('newfold-staging-page',  getClasses())}>
             <Components.SectionContainer className={'wppbh-app-staging-container'}>
 				<div className={methods.classnames('newfold-staging-wrapper')}>
 					<Components.SectionHeader

--- a/includes/Staging.php
+++ b/includes/Staging.php
@@ -390,6 +390,7 @@ class Staging {
 			$config['production_url'],
 			$config['staging_url'],
 			get_current_user_id(),
+			container()->plugin()->id,
 		);
 
 		if ( $args && is_array( $args ) ) {

--- a/includes/StagingApi.php
+++ b/includes/StagingApi.php
@@ -18,14 +18,14 @@ class StagingApi extends \WP_REST_Controller {
 	protected $namespace = 'newfold-staging/v1';
 
 	/**
-	 * An instance of the BluehostStaging class.
+	 * An instance of the Staging class.
 	 *
 	 * @var Staging
 	 */
 	protected $staging;
 
 	/**
-	 * Bluehost_Staging_Controller constructor.
+	 * Staging_Controller constructor.
 	 *
 	 * @param Container $container An instance of the Container class.
 	 */

--- a/lib/.staging
+++ b/lib/.staging
@@ -164,7 +164,7 @@ function sso_staging {
 	fi
 	wp eval 'file_exists( WPMU_PLUGIN_DIR . "/sso.php" ) ? unlink( WPMU_PLUGIN_DIR . "/sso.php" ) : null;' --path=$STAGING_DIR --skip-themes --skip-plugins --quiet
 	LINK=$(wp newfold sso --url-only --id=$1 --path=$STAGING_DIR)
-	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=bluehost#\/staging\"\}
+	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=$PLUGIN_ID#\/staging\"\}
 }
 
 function sso_production {
@@ -174,7 +174,7 @@ function sso_production {
 	fi
 	wp eval 'file_exists( WPMU_PLUGIN_DIR . "/sso.php" ) ? unlink( WPMU_PLUGIN_DIR . "/sso.php" ) : null;' --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet
 	LINK=$(wp newfold sso --url-only --id=$1 --path=$PRODUCTION_DIR)
-	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=bluehost#\/staging\"\}
+	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=$PLUGIN_ID#\/staging\"\}
 }
 
 function error {
@@ -208,6 +208,7 @@ STAGING_DIR=$4
 PRODUCTION_URL=$5
 STAGING_URL=$6
 USER_ID=$7
+PLUGIN_ID=$8
 DB_HOST=$(wp eval 'echo DB_HOST;' --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet)
 DB_NAME=$(wp eval 'echo DB_NAME;' --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet)
 DB_USER=$(wp eval 'echo DB_USER;' --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet)
@@ -231,7 +232,7 @@ CONFIG=$(wp option get staging_config --format=json --path=$PRODUCTION_DIR --ski
 
 wp transient set nfd_staging_lock "true" 120 --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet
 
-$1 "$8"
+$1 "$9"
 
 wp transient delete nfd_staging_lock --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet
 
@@ -242,4 +243,5 @@ wp transient delete nfd_staging_lock --path=$PRODUCTION_DIR --skip-themes --skip
 # $5 is production url
 # $6 is staging url
 # $7 is current user id
-# $8 is function param 1
+# $8 is plugin id/brand
+# $9 is function param 1


### PR DESCRIPTION
This updates the staging script to support more brands than just Bluehost. 

Currently, there are a couple of `bluehost` links hardcoded in the bash script which handles switching environments (switching to staging and back into production sites) with the sso functionality. This uses the plugin id value from the container and passes it as a command arg so the script can pick that up for these redirecting URLs once the sso completes.

There is also a small update to use a text value from the defaults. This reminds me we should also add translations (At least Portuguese) for all these default text strings (https://github.com/newfold-labs/wp-module-staging/blob/main/components/staging/defaultText.js) so the staging feature is usable for HostGator Latam customers.

__

I also want to note that this is a small update so we can add the module to other brand plugins. Ideally, we can update the whole module to utilize the staging API soon. I believe these endpoints are ready for us to use. That update will require much more work and theoretically will make this staging feature much more robust, as this bash script tends to fail often.