### PR TITLE
update cypress test after changing components

### DIFF
--- a/tests/cypress/integration/staging.cy.js
+++ b/tests/cypress/integration/staging.cy.js
@@ -152,13 +152,11 @@ describe('Staging Page', function () {
         cy.get('#staging-create-button')
             .should('be.visible')
             .click();
-        cy.wait(100);
-        
-        cy.get( appClass + '-page')
+        cy.get('.newfold-staging-page')
             .should('have.class', 'is-thinking');
         cy.wait('@stagingCreate');
 
-        cy.get( appClass + '-page')
+        cy.get('.newfold-staging-page')
             .should('not.have.class', 'is-thinking');
 
         cy.get('.newfold-staging-staging')


### PR DESCRIPTION
The container element changed a bit once using the components, so we don't need to use the appClass anymore and can just use the module-level class as a selector.