### PR TITLE
Switch to staging environment toast label text issue

### DIFF
--- a/components/staging/index.js
+++ b/components/staging/index.js
@@ -256,7 +256,10 @@ const Staging = ({methods, constants, ...props}) => {
 				if ( response.hasOwnProperty( 'load_page' ) ) {
 					window.location.href = response.load_page;
 					// navigate(response.load_page);
-					makeNotice( 'redirecting', constants.text.switching, constants.text.switchToProductionNoticeCompleteText, 'success', 8000 );
+					alert("changed to "+env)
+					const notifyMessageText = env === "production" ? constants.text.switchToProductionNoticeCompleteText : constants.text.switchToStagingNoticeCompleteText;
+					alert(notifyMessageText)
+					makeNotice( 'redirecting', constants.text.switching, notifyMessageText, 'success', 8000 );
 				} else if ( response.hasOwnProperty('status') && response.status === 'error' ) {
 					setError(response.message);
 				} else {

--- a/components/staging/index.js
+++ b/components/staging/index.js
@@ -256,9 +256,7 @@ const Staging = ({methods, constants, ...props}) => {
 				if ( response.hasOwnProperty( 'load_page' ) ) {
 					window.location.href = response.load_page;
 					// navigate(response.load_page);
-					alert("changed to "+env)
 					const notifyMessageText = env === "production" ? constants.text.switchToProductionNoticeCompleteText : constants.text.switchToStagingNoticeCompleteText;
-					alert(notifyMessageText)
 					makeNotice( 'redirecting', constants.text.switching, notifyMessageText, 'success', 8000 );
 				} else if ( response.hasOwnProperty('status') && response.status === 'error' ) {
 					setError(response.message);


### PR DESCRIPTION
## Proposed changes

`PRESS0-1962` : In a customer production website, clicking on the staging website toggle, successfully switched from production to staging but the wrong label was presented in the process.

<img width="2056" alt="CleanShot 2024-07-17 at 14 05 17@2x" src="https://github.com/user-attachments/assets/1d6e9985-3150-4b68-81a7-a87371f1aad1">


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
