### PR TITLE
creating and clone staging active plugins prefix gets replaced

### DIFF
--- a/lib/.staging
+++ b/lib/.staging
@@ -103,6 +103,26 @@ run_or_fail() {
   fi
 }
 
+# Table-prefix sed replaces wp_* everywhere, including inside serialized option values
+# (e.g. wp_mail_smtp.php -> staging_wp_mail_smtp.php). Re-copy active_plugins from production.
+restore_staging_active_plugins_from_production() {
+  local prod_path="$1"
+  local staging_path="$2"
+  local log_step="$3"
+  log "INFO" "$log_step" "Restoring active_plugins from production (SQL prefix step must not alter plugin paths)"
+  local ap_json
+  set +e
+  ap_json=$(wp option get active_plugins --format=json --path="$prod_path" --skip-themes --skip-plugins --quiet 2>/dev/null)
+  local ap_get_status=$?
+  set -e
+  if [ $ap_get_status -ne 0 ] || [ -z "$ap_json" ]; then
+    log "ERROR" "$log_step:get" "Unable to read active_plugins from production (exit=$ap_get_status)"
+    error "Unable to read active_plugins from production."
+  fi
+  run_or_fail "$log_step:update" "Unable to restore active_plugins on staging." \
+    wp option update active_plugins "$ap_json" --format=json --path="$staging_path" --skip-themes --skip-plugins --quiet
+}
+
 # --- Cleanup on exit ---
 cleanup() {
   release_staging_lock
@@ -764,6 +784,9 @@ create() {
   fi
   log "DEBUG" "create:after_search_replace" "Completed search replace URLs"
 
+  log "INFO" "create" "[STEP] Restore active_plugins from production"
+  restore_staging_active_plugins_from_production "$PRODUCTION_DIR" "$STAGING_DIR" "create:restore_active_plugins"
+
   log "DEBUG" "create:before_import_config" "Starting import config"
   # Import config
   log "INFO" "create" "[STEP] Import config."
@@ -1052,6 +1075,8 @@ clone() {
     run_or_fail "clone:core_download" "Unable to install WordPress in staging directory." wp core download --version="$WP_VER" --force
   fi
   run_or_fail "clone:search_replace" "Unable to update URLs on staging." wp search-replace "$PRODUCTION_URL" "$STAGING_URL" --skip-themes --skip-plugins --quiet
+  log "INFO" "clone" "[STEP] Restore active_plugins from production"
+  restore_staging_active_plugins_from_production "$PRODUCTION_DIR" "$STAGING_DIR" "clone:restore_active_plugins"
   run_or_fail "clone:import_config" "Unable to import global config on staging." wp option update staging_config "$STAGING_CONFIG_JSON" --format=json --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
   run_or_fail "clone:coming_soon" "Unable to turn on Coming Soon page in staging." wp option update nfd_coming_soon 'true' --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
   run_or_fail "clone:rewrite_flush" "Unable to flush rewrite rules." wp rewrite flush --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet


### PR DESCRIPTION

## Proposed changes
During the creation or cloning of a staging environment, plugins with the wp_ prefix are renamed to use the staging_ prefix. This renaming causes failures in the validate_active_plugins() check, which results in all plugins being deactivated. Consequently, site switching and other related operations are also impacted.

This issue can be resolved by copying the active plugins from the production environment to the staging environment after the prefix replacement process is completed.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->