### PR TITLE
Prefix replacing logic fix

### DIFF
--- a/lib/.staging
+++ b/lib/.staging
@@ -103,24 +103,45 @@ run_or_fail() {
   fi
 }
 
-# Table-prefix sed replaces wp_* everywhere, including inside serialized option values
-# (e.g. wp_mail_smtp.php -> staging_wp_mail_smtp.php). Re-copy active_plugins from production.
-restore_staging_active_plugins_from_production() {
-  local prod_path="$1"
-  local staging_path="$2"
-  local log_step="$3"
-  log "INFO" "$log_step" "Restoring active_plugins from production (SQL prefix step must not alter plugin paths)"
-  local ap_json
+
+rename_prefixed_keys_to_staging() {
+  local wp_path="$1"
+  local log_step="$2"
+  log "INFO" "$log_step" "Renaming prefix-dependent option names and meta keys to staging prefix"
   set +e
-  ap_json=$(wp option get active_plugins --format=json --path="$prod_path" --skip-themes --skip-plugins --quiet 2>/dev/null)
-  local ap_get_status=$?
+  wp db query "UPDATE \`staging_${DB_PREFIX}options\` SET option_name = CONCAT('staging_', option_name) WHERE option_name LIKE '${DB_PREFIX}%';" \
+    --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
+  local opt_status=$?
+  wp db query "UPDATE \`staging_${DB_PREFIX}usermeta\` SET meta_key = CONCAT('staging_', meta_key) WHERE meta_key LIKE '${DB_PREFIX}%';" \
+    --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
+  local meta_status=$?
   set -e
-  if [ $ap_get_status -ne 0 ] || [ -z "$ap_json" ]; then
-    log "ERROR" "$log_step:get" "Unable to read active_plugins from production (exit=$ap_get_status)"
-    error "Unable to read active_plugins from production."
+  if [ $opt_status -ne 0 ]; then
+    log "ERROR" "$log_step" "Failed to rename prefixed option names (exit=$opt_status)"
   fi
-  run_or_fail "$log_step:update" "Unable to restore active_plugins on staging." \
-    wp option update active_plugins "$ap_json" --format=json --path="$staging_path" --skip-themes --skip-plugins --quiet
+  if [ $meta_status -ne 0 ]; then
+    log "ERROR" "$log_step" "Failed to rename prefixed meta keys (exit=$meta_status)"
+  fi
+}
+
+rename_prefixed_keys_to_production() {
+  local wp_path="$1"
+  local log_step="$2"
+  log "INFO" "$log_step" "Renaming staging-prefixed option names and meta keys back to production prefix"
+  set +e
+  wp db query "UPDATE \`${DB_PREFIX}options\` SET option_name = REPLACE(option_name, 'staging_${DB_PREFIX}', '${DB_PREFIX}') WHERE option_name LIKE 'staging\_${DB_PREFIX}%';" \
+    --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
+  local opt_status=$?
+  wp db query "UPDATE \`${DB_PREFIX}usermeta\` SET meta_key = REPLACE(meta_key, 'staging_${DB_PREFIX}', '${DB_PREFIX}') WHERE meta_key LIKE 'staging\_${DB_PREFIX}%';" \
+    --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
+  local meta_status=$?
+  set -e
+  if [ $opt_status -ne 0 ]; then
+    log "ERROR" "$log_step" "Failed to rename prefixed option names (exit=$opt_status)"
+  fi
+  if [ $meta_status -ne 0 ]; then
+    log "ERROR" "$log_step" "Failed to rename prefixed meta keys (exit=$meta_status)"
+  fi
 }
 
 # --- Cleanup on exit ---
@@ -656,7 +677,7 @@ create() {
   fi
   set +e
   sed -E \
-    -e "s/(\b|[\`])${DB_PREFIX}([a-zA-Z0-9_]+)(\b|[\`])/\\1staging_${DB_PREFIX}\\2\\3/g" \
+    -e "s/\`${DB_PREFIX}([a-zA-Z0-9_]+)\`/\`staging_${DB_PREFIX}\\1\`/g" \
     -e "s/CONSTRAINT \`(prod_)?([^\`]+)\`/CONSTRAINT \`staging_\\2\`/g" \
     -e "s/TRIGGER \`(prod_)?([^\`]+)\`/TRIGGER \`staging_\\2\`/g" \
     -e "s/\/\*\![0-9]+ DEFINER=[^*]*\*\///g" \
@@ -784,8 +805,8 @@ create() {
   fi
   log "DEBUG" "create:after_search_replace" "Completed search replace URLs"
 
-  log "INFO" "create" "[STEP] Restore active_plugins from production"
-  restore_staging_active_plugins_from_production "$PRODUCTION_DIR" "$STAGING_DIR" "create:restore_active_plugins"
+  log "INFO" "create" "[STEP] Rename prefix-dependent keys in staging DB"
+  rename_prefixed_keys_to_staging "$STAGING_DIR" "create:rename_prefixed_keys"
 
   log "DEBUG" "create:before_import_config" "Starting import config"
   # Import config
@@ -1013,7 +1034,7 @@ clone() {
   fi
 
   sed -E \
-    -e "s/(\b|[\`])${DB_PREFIX}([a-zA-Z0-9_]+)(\b|[\`])/\\1staging_${DB_PREFIX}\\2\\3/g" \
+    -e "s/\`${DB_PREFIX}([a-zA-Z0-9_]+)\`/\`staging_${DB_PREFIX}\\1\`/g" \
     -e "s/CONSTRAINT \`(prod_)?([^\`]+)\`/CONSTRAINT \`staging_\\2\`/g" \
     -e "s/TRIGGER \`(prod_)?([^\`]+)\`/TRIGGER \`staging_\\2\`/g" \
     "$STAGING_DIR/.export-sql" > "$tmpfile"
@@ -1075,8 +1096,8 @@ clone() {
     run_or_fail "clone:core_download" "Unable to install WordPress in staging directory." wp core download --version="$WP_VER" --force
   fi
   run_or_fail "clone:search_replace" "Unable to update URLs on staging." wp search-replace "$PRODUCTION_URL" "$STAGING_URL" --skip-themes --skip-plugins --quiet
-  log "INFO" "clone" "[STEP] Restore active_plugins from production"
-  restore_staging_active_plugins_from_production "$PRODUCTION_DIR" "$STAGING_DIR" "clone:restore_active_plugins"
+  log "INFO" "clone" "[STEP] Rename prefix-dependent keys in staging DB"
+  rename_prefixed_keys_to_staging "$STAGING_DIR" "clone:rename_prefixed_keys"
   run_or_fail "clone:import_config" "Unable to import global config on staging." wp option update staging_config "$STAGING_CONFIG_JSON" --format=json --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
   run_or_fail "clone:coming_soon" "Unable to turn on Coming Soon page in staging." wp option update nfd_coming_soon 'true' --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
   run_or_fail "clone:rewrite_flush" "Unable to flush rewrite rules." wp rewrite flush --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
@@ -1204,7 +1225,7 @@ deploy_db() {
     log "INFO" "deploy_db" "Replacing staging prefixes in SQL"
     TMP_PREFIX_FILE=$(mktemp)
     if ! sed -E \
-      -e "s/(\b|[\`])staging_${DB_PREFIX}([a-zA-Z0-9_]+)(\b|[\`])/\\1${DB_PREFIX}\\2\\3/g" \
+      -e "s/\`staging_${DB_PREFIX}([a-zA-Z0-9_]+)\`/\`${DB_PREFIX}\\1\`/g" \
       -e "s/CONSTRAINT \`(staging_)?([^\`]+)\`/CONSTRAINT \`prod_\\2\`/g" \
       -e "s/TRIGGER \`(staging_)?([^\`]+)\`/TRIGGER \`prod_\\2\`/g" \
       "$STAGING_DIR/.export-sql" > "$TMP_PREFIX_FILE" 2>&1; then
@@ -1276,6 +1297,9 @@ deploy_db() {
     if [ $RC -ne 0 ]; then
       fail_and_exit "Unable to update URLs on production. Output: $OUTPUT"
     fi
+
+    # 6b. Rename staging-prefixed option names and meta keys back to production prefix
+    rename_prefixed_keys_to_production "$PRODUCTION_DIR" "deploy_db:rename_prefixed_keys"
 
     # 7. Update staging_environment
     log "INFO" "deploy_db" "Updating staging_environment to production"

--- a/lib/.staging
+++ b/lib/.staging
@@ -103,6 +103,26 @@ run_or_fail() {
   fi
 }
 
+# Table-prefix sed replaces wp_* everywhere, including inside serialized option values
+# (e.g. wp_mail_smtp.php -> staging_wp_mail_smtp.php). Re-copy active_plugins from production.
+restore_staging_active_plugins_from_production() {
+  local prod_path="$1"
+  local staging_path="$2"
+  local log_step="$3"
+  log "INFO" "$log_step" "Restoring active_plugins from production (SQL prefix step must not alter plugin paths)"
+  local ap_json
+  set +e
+  ap_json=$(wp option get active_plugins --format=json --path="$prod_path" --skip-themes --skip-plugins --quiet 2>/dev/null)
+  local ap_get_status=$?
+  set -e
+  if [ $ap_get_status -ne 0 ] || [ -z "$ap_json" ]; then
+    log "ERROR" "$log_step:get" "Unable to read active_plugins from production (exit=$ap_get_status)"
+    error "Unable to read active_plugins from production."
+  fi
+  run_or_fail "$log_step:update" "Unable to restore active_plugins on staging." \
+    wp option update active_plugins "$ap_json" --format=json --path="$staging_path" --skip-themes --skip-plugins --quiet
+}
+
 # --- Cleanup on exit ---
 cleanup() {
   release_staging_lock
@@ -764,6 +784,9 @@ create() {
   fi
   log "DEBUG" "create:after_search_replace" "Completed search replace URLs"
 
+  log "INFO" "create" "[STEP] Restore active_plugins from production"
+  restore_staging_active_plugins_from_production "$PRODUCTION_DIR" "$STAGING_DIR" "create:restore_active_plugins"
+
   log "DEBUG" "create:before_import_config" "Starting import config"
   # Import config
   log "INFO" "create" "[STEP] Import config."
@@ -1052,6 +1075,8 @@ clone() {
     run_or_fail "clone:core_download" "Unable to install WordPress in staging directory." wp core download --version="$WP_VER" --force
   fi
   run_or_fail "clone:search_replace" "Unable to update URLs on staging." wp search-replace "$PRODUCTION_URL" "$STAGING_URL" --skip-themes --skip-plugins --quiet
+  log "INFO" "clone" "[STEP] Restore active_plugins from production"
+  restore_staging_active_plugins_from_production "$PRODUCTION_DIR" "$STAGING_DIR" "clone:restore_active_plugins"
   run_or_fail "clone:import_config" "Unable to import global config on staging." wp option update staging_config "$STAGING_CONFIG_JSON" --format=json --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
   run_or_fail "clone:coming_soon" "Unable to turn on Coming Soon page in staging." wp option update nfd_coming_soon 'true' --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
   run_or_fail "clone:rewrite_flush" "Unable to flush rewrite rules." wp rewrite flush --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet

--- a/lib/.staging
+++ b/lib/.staging
@@ -127,20 +127,35 @@ rename_prefixed_keys_to_staging() {
 rename_prefixed_keys_to_production() {
   local wp_path="$1"
   local log_step="$2"
-  log "INFO" "$log_step" "Renaming staging-prefixed option names and meta keys back to production prefix"
+  log "INFO" "$log_step" "Cleaning staging-prefixed option names and meta keys for production"
   set +e
-  wp db query "UPDATE \`${DB_PREFIX}options\` SET option_name = REPLACE(option_name, 'staging_${DB_PREFIX}', '${DB_PREFIX}') WHERE option_name LIKE 'staging\_${DB_PREFIX}%';" \
+
+  # Options: drop staging-prefixed rows where the un-prefixed version already exists
+  wp db query "DELETE o1 FROM \`${DB_PREFIX}options\` o1 INNER JOIN \`${DB_PREFIX}options\` o2 ON o2.option_name = REPLACE(o1.option_name, 'staging_', '') WHERE o1.option_name LIKE 'staging\_${DB_PREFIX}%' AND o1.option_name != o2.option_name;" \
+    --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
+  local opt_del_status=$?
+
+  # Options: rename remaining staging-prefixed rows (no conflict)
+  wp db query "UPDATE \`${DB_PREFIX}options\` SET option_name = REPLACE(option_name, 'staging_', '') WHERE option_name LIKE 'staging\_${DB_PREFIX}%';" \
     --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
   local opt_status=$?
-  wp db query "UPDATE \`${DB_PREFIX}usermeta\` SET meta_key = REPLACE(meta_key, 'staging_${DB_PREFIX}', '${DB_PREFIX}') WHERE meta_key LIKE 'staging\_${DB_PREFIX}%';" \
+
+  # Usermeta: drop staging-prefixed rows where the un-prefixed version exists for the same user
+  wp db query "DELETE m1 FROM \`${DB_PREFIX}usermeta\` m1 INNER JOIN \`${DB_PREFIX}usermeta\` m2 ON m2.user_id = m1.user_id AND m2.meta_key = REPLACE(m1.meta_key, 'staging_', '') WHERE m1.meta_key LIKE 'staging\_${DB_PREFIX}%' AND m1.meta_key != m2.meta_key;" \
+    --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
+  local meta_del_status=$?
+
+  # Usermeta: rename remaining staging-prefixed rows (no conflict)
+  wp db query "UPDATE \`${DB_PREFIX}usermeta\` SET meta_key = REPLACE(meta_key, 'staging_', '') WHERE meta_key LIKE 'staging\_${DB_PREFIX}%';" \
     --path="$wp_path" --skip-themes --skip-plugins --quiet 2>/dev/null
   local meta_status=$?
+
   set -e
-  if [ $opt_status -ne 0 ]; then
-    log "ERROR" "$log_step" "Failed to rename prefixed option names (exit=$opt_status)"
+  if [ $opt_del_status -ne 0 ] || [ $opt_status -ne 0 ]; then
+    log "ERROR" "$log_step" "Failed to clean prefixed option names (del=$opt_del_status, rename=$opt_status)"
   fi
-  if [ $meta_status -ne 0 ]; then
-    log "ERROR" "$log_step" "Failed to rename prefixed meta keys (exit=$meta_status)"
+  if [ $meta_del_status -ne 0 ] || [ $meta_status -ne 0 ]; then
+    log "ERROR" "$log_step" "Failed to clean prefixed meta keys (del=$meta_del_status, rename=$meta_status)"
   fi
 }
 


### PR DESCRIPTION
## Proposed changes
While creating, cloning and deploying database we add/remove staging prefix from database which makes issue because some data gets corrupted like if active_plugins in options table has a plugin with wp prefix gets replaced it break and all plugin gets deactivated causing switching staging failure and can cause other issues as well. Similarly while deploying db if plugin add a option value on its own and don't follow the db prefix logic then wp_* and staging_wp_* exists and removing staging_ prefix make it a duplicate causing db import fail as option name is unique value column. In create staging I have added a change in which only options name and user meta column will get staging_ prefix not other columns so value remains preserved and while deploying db remove stale staging prefixed rows so it can't create duplicate entries.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->