### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required by reusable translations workflow to commit translation updates.
       pull-requests: write # Required by reusable translations workflow to open or update translation PRs.
+    timeout-minutes: 30
     with:
       text_domain: 'wp-module-staging'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required by reusable translations workflow to commit translation updates.
+      pull-requests: write # Required by reusable translations workflow to open or update translation PRs.
     with:
       text_domain: 'wp-module-staging'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the reusable workflow can clone this repository.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Cypress
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required so the reusable workflow can clone this repository.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required by reusable codecoverage to push coverage badge and GitHub Pages output.
+      pull-requests: write # Required by reusable codecoverage to comment or update pull requests.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required by reusable codecoverage to push coverage badge and GitHub Pages output.
       pull-requests: write # Required by reusable codecoverage to comment or update pull requests.
+    timeout-minutes: 90
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # Required to clone the repository for checkout.
+      actions: read    # Required to restore caches via actions/cache.
+      actions: write   # Required to save caches on cache miss.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,7 @@ jobs:
       contents: read   # Required to clone the repository for checkout.
       actions: read    # Required to restore caches via actions/cache.
       actions: write   # Required to save caches on cache miss.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read   # Required to clone the repository for checkout.
-      actions: read    # Required to restore caches via actions/cache.
-      actions: write   # Required to save caches on cache miss.
     timeout-minutes: 30
     steps:
 

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required by reusable module-prep-release to push release prep branches/commits.
       pull-requests: write # Required by reusable module-prep-release to open or update the release PR.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -23,8 +23,8 @@ jobs:
     name: Prepare Release
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
-        contents: write
-        pull-requests: write
+      contents: write      # Required by reusable module-prep-release to push release prep branches/commits.
+      pull-requests: write # Required by reusable module-prep-release to open or update the release PR.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,16 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repository for checkout.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repository for checkout.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/auto-translate.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/lint.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/newfold-prep-release.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed) |
| Permissions commit | `4c7c686` |
| Timeouts commit | `4fe90e1` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/satis-webhook.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml` (replaced workflow-level `permissions: contents: read` with the standard default-deny block and comments) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml` (replaced workflow-level `permissions: contents: read` with the standard default-deny block and comments) |
| `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/auto-translate.yml` already had `permissions: {}` but was updated to include the required preceding comment block. | — |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `contents: read` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `actions: read`, `actions: write` [2] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml | 1 job was missing an explicit `permissions:` directive; 1 job was tightened/re-scoped in placement and documentation | get-repo-name | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml | 1 job was missing an explicit `permissions:` directive; 1 job was tightened/re-scoped in placement and documentation | codecoverage | `contents: write`, `pull-requests: write` (moved to immediately follow `uses:`; inline rationale comments added) [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/auto-translate.yml | 1 job was updated (not net-new scopes, but brought into compliance with job structure/comments) | translate | `contents: write`, `pull-requests: write` (now immediately after `uses:`; inline rationale comments added) [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml | 2 jobs updated for least-privilege defaults and call ordering | setup | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml | 2 jobs updated for least-privilege defaults and call ordering | bluehost | `contents: read` (moved to immediately follow `uses:`; inline rationale comment added) [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/newfold-prep-release.yml | 1 job was missing inline permission rationale comments / consistent formatting (scopes unchanged) | prep-release | `contents: write`, `pull-requests: write` (comments + indentation normalized) [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml` :: workflow: BEFORE `permissions: contents: read` -> AFTER default-deny `permissions: {}` (with required comments) -- Avoid granting a workflow-wide default `contents: read` to every job; scope per job instead. [3] |
| 2 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml` :: workflow: BEFORE `permissions: contents: read` -> AFTER default-deny `permissions: {}` (with required comments) -- Same rationale; `setup` does not checkout and does not need repository contents access. [3] |
| 3 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/auto-translate.yml` :: `translate`: BEFORE `permissions` preceding `uses:` -> AFTER `uses:` then `permissions:` -- Aligns with required placement for callable workflow jobs. [3] |
| 4 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/newfold-prep-release.yml` :: `prep-release`: BEFORE inconsistently indented `permissions` keys -> AFTER normalized YAML indentation with inline comments -- Cosmetic/structure fix; scopes unchanged. [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/auto-translate.yml | translate | `30` | Translation automation can pull/push and open PRs; 30 minutes is a reasonable ceiling versus an unbounded run. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml | setup | `5` | Only derives branch metadata; should finish quickly. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/brand-plugin-test-playwright.yml | bluehost | `90` | Invokes a reusable Playwright/brand-plugin integration workflow that builds and tests multiple repos; longer wall time is plausible. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml | get-repo-name | `5` | Single-step metadata extraction; short cap prevents a stuck runner. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/codecoverage-main.yml | codecoverage | `90` | Calls a multi-PHP reusable coverage workflow (tests + publishing); allows headroom beyond the reusable job’s internal step timeouts. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/lint.yml | phpcs | `30` | Composer install + PHPCS on diff sets should complete well under this cap under normal conditions. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/newfold-prep-release.yml | prep-release | `30` | Release prep can involve checkouts, installs, commits, and `gh pr create`; 30 minutes matches typical module release automation expectations. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/satis-webhook.yml | webhook | `30` | Lightweight checkout + repository dispatch; 30 minutes is a safe default for runaway protection. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-staging/.github/workflows/lint.yml` lists `actions` twice (`actions: read` then `actions: write`). Many YAML parsers will treat this as duplicate keys (often resolving to the last entry), but it is worth human review; a single `actions: write` (if acceptable for least privilege vs. `read`-only scenarios) may be clearer. |
| 2 | Callable workflows pin to `@main` (`newfold-labs/workflows/...`), so future upstream changes could alter required token scopes; re-validate if those reusables gain new GitHub API steps. |
| 3 | `peter-evans/repository-dispatch` uses `secrets.WEBHOOK_TOKEN` (not `GITHUB_TOKEN`); job permissions focus on checkout needs. |


