### PR TITLE
Fix SSO switch to use the current admin user.

### DIFF
--- a/includes/StagingCLI.php
+++ b/includes/StagingCLI.php
@@ -121,9 +121,17 @@ class StagingCLI extends \WP_CLI_Command {
 	/**
 	 * Get an admin user ID.
 	 *
+	 * Prefers the currently logged-in administrator when available,
+	 * otherwise falls back to the first administrator found.
+	 *
 	 * @return int
 	 */
 	protected function get_admin_user_id() {
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id && user_can( $current_user_id, 'manage_options' ) ) {
+			return $current_user_id;
+		}
 
 		$user_id = 0;
 

--- a/lib/.staging
+++ b/lib/.staging
@@ -928,7 +928,9 @@ destroy() {
 sso_staging() {
 
   log "DEBUG" "SSO staging"
-  if [ -z "$1" ]; then
+  # Prefer explicit function_param (from switchTo), then USER_ID from the current request.
+  local SSO_USER_ID="${11:-$USER_ID}"
+  if [ -z "$SSO_USER_ID" ] || [ "$SSO_USER_ID" = "0" ]; then
     error 'No user provided.'
   fi
 
@@ -970,9 +972,9 @@ sso_staging() {
     wp eval 'file_exists( WPMU_PLUGIN_DIR . "/sso.php" ) ? unlink( WPMU_PLUGIN_DIR . "/sso.php" ) : null;' \
     --path="$STAGING_DIR" --skip-themes --skip-plugins --quiet
 
-  log "INFO" "sso_staging" "Requesting SSO link from wp newfold sso"
+  log "INFO" "sso_staging" "Requesting SSO link from wp newfold sso for user $SSO_USER_ID"
 
-  LINK=$(wp newfold sso --url-only --id="$1" --path="$STAGING_DIR" 2> >(while read -r line; do log "ERROR" "sso_staging" "$line"; done) | head -n 1)
+  LINK=$(wp newfold sso --url-only --id="$SSO_USER_ID" --path="$STAGING_DIR" 2> >(while read -r line; do log "ERROR" "sso_staging" "$line"; done) | head -n 1)
 
   # Remove newline (\n), carriage return (\r)
   LINK="${LINK//$'\n'/}"
@@ -990,18 +992,20 @@ sso_staging() {
     error "Unable to create SSO link for staging."
   fi
 
-  log "SUCCESS" "sso_staging" "SSO to staging successful for user $1."
+  log "SUCCESS" "sso_staging" "SSO to staging successful for user $SSO_USER_ID."
 
   echo '{"status":"success","load_page":"'"$LINK"'&redirect=admin.php?page=nfd-staging"}'
 }
 
 sso_production() {
   log "DEBUG" "SSO Production"
-  if [ -z "$1" ]; then
+  # Prefer explicit function_param (from switchTo), then USER_ID from the current request.
+  local SSO_USER_ID="${11:-$USER_ID}"
+  if [ -z "$SSO_USER_ID" ] || [ "$SSO_USER_ID" = "0" ]; then
     error 'No user provided.'
   fi
   wp eval 'file_exists( WPMU_PLUGIN_DIR . "/sso.php" ) ? unlink( WPMU_PLUGIN_DIR . "/sso.php" ) : null;' --path=$PRODUCTION_DIR --skip-themes --skip-plugins --quiet
-  LINK=$(wp newfold sso --url-only --id=$1 --path=$PRODUCTION_DIR)
+  LINK=$(wp newfold sso --url-only --id="$SSO_USER_ID" --path=$PRODUCTION_DIR)
 
   # Remove newline (\n) e carriage return (\r) characters from the link
   LINK="${LINK//$'\n'/}"
@@ -1014,7 +1018,7 @@ sso_production() {
   # (this removes the Unicode codepoint U+FEFF anywhere)
   LINK="$(printf '%s' "$LINK" | perl -CS -pe 's/\x{FEFF}//g')"
 
-  log "SUCCESS" "sso_production" "SSO to production successful for user $USER_ID."
+  log "SUCCESS" "sso_production" "SSO to production successful for user $SSO_USER_ID."
   echo '{"status":"success","load_page":"'$LINK'&redirect=admin.php?page=nfd-staging"}'
 }
 


### PR DESCRIPTION
Pass the correct user ID into sso_staging/sso_production instead of the command name, and prefer the logged-in administrator when selecting a fallback user.
## Proposed changes
Fixes SSO environment switching so the logged-in administrator is reused on the destination site, instead of always falling back to the first admin.
**Root cause:** 
`sso_staging` / `sso_production` in `lib/.staging` passed `$1` (the command name, e.g. `sso_staging`) to `wp newfold sso --id=...`. That ID was invalid, so the SSO link had no `user` param and the legacy SSO handler fell back to the first administrator.
**Changes:**
- `lib/.staging`: use `${11:-$USER_ID}` (explicit `switchTo` arg, then request user) for SSO `--id`
- `includes/StagingCLI.php`: prefer the current logged-in admin in `get_admin_user_id()`, with first-admin fallback
Related Jira: https://newfold.atlassian.net/browse/PRESS0-4852
## Type of Change
#### Production
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)
#### Development
- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update
## Visual
N/A — backend/SSO flow change; no UI layout changes.
**Manual verification:**
1. Have at least two administrator users
2. Log in as an admin that is **not** the first in the list
3. Switch to Staging (and back to Production)
4. Confirm you are logged in as the same user on the destination site
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
## Further comments
The UI/API path already passed `get_current_user_id()` into `switchTo()` / `runCommand()`, but the shell script ignored it by reading `$1`. If the target site does not contain that user ID, existing SSO legacy fallback still selects the first administrator.